### PR TITLE
Fix deprecated dependency ipc

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 // Electron doesn't support notifications in Windows yet. https://github.com/atom/electron/issues/262
 // So we hijack the Notification API.'
-const ipc = require('ipc');
+const ipc = require('electron').ipcRenderer;
 
 module.exports = () => {
 	const OldNotification = Notification;


### PR DESCRIPTION
`require('ipc')` is deprecated
